### PR TITLE
[TASK] Process actual login requests only

### DIFF
--- a/Classes/YubikeyAuthService.php
+++ b/Classes/YubikeyAuthService.php
@@ -89,6 +89,10 @@ class YubikeyAuthService extends \TYPO3\CMS\Core\Authentication\AbstractAuthenti
         // 0 means authentication failure
         $ret = 0;
 
+        // only handle Yubikey for actual login requests
+        if (empty($this->login['status']) || $this->login['status'] !== 'login') {
+            return 100;
+        }
         // Check if user Yubikey-Authentication is enabled for this user
         if (!$user['tx_sfyubikey_yubikey_enable']) {
             $this->logger->debug(


### PR DESCRIPTION
This change ensures authentication service is only invoked when an
actual login request shall be handled - otherwise a change for TYPO3
core (9.5, 10.4, 11-dev) introduces potential side effects, see
https://review.typo3.org/c/Packages/TYPO3.CMS/+/66630